### PR TITLE
Take relative directories into account

### DIFF
--- a/wasm2map/src/lib.rs
+++ b/wasm2map/src/lib.rs
@@ -152,13 +152,18 @@ impl WASM {
                     let mut path = PathBuf::new();
 
                     if let Some(file) = row.file(header) {
-                        // The directory index 0 is defined to correspond to the compilation unit directory.
-                        if file.directory_index() != 0 {
-                            if let Some(dir) = file.directory(header) {
-                                path.push(
-                                    dwarf.attr_string(&unit, dir)?.to_string_lossy().as_ref(),
-                                );
+                        if let Some(dir) = file.directory(header) {
+                            let dir = &dwarf.attr_string(&unit, dir)?.to_string_lossy();
+                            let dir = Path::new(dir.as_ref());
+
+                            // Relative directories are relative to the compilation unit directory.
+                            if dir.is_relative() {
+                                if let Some(dir) = unit.comp_dir {
+                                    path.push(dir.to_string_lossy().as_ref())
+                                }
                             }
+
+                            path.push(dir);
                         }
 
                         path.push(

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -25,6 +25,21 @@ fn can_create_sourcemap() {
 }
 
 #[test]
+fn relative_paths() {
+    testutils::run_test(|out| {
+        if let Ok(mapper) = WASM::load(&out) {
+            let sourcemap = mapper.map_v3();
+
+            // Any fixed relative path should have at least a `/` beforehand.
+            assert!(sourcemap.contains("/library/core/src/any.rs"));
+            assert!(sourcemap.contains("/library/core/src/panicking.rs"));
+        } else {
+            unreachable!()
+        }
+    });
+}
+
+#[test]
 fn can_add_and_update_sourcemap() {
     testutils::run_test(|out| {
         // Set up the test byte data

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -223,7 +223,7 @@ mod testutils {
     pub fn setup() -> String {
         let mut out = get_target_dir();
         out.push("target");
-        out.push("test.wasm");
+        out.push(format!("test{}.wasm", get_thread_id()));
 
         build_with_rustc("fn main() {}", out.display().to_string().as_str());
 
@@ -234,8 +234,16 @@ mod testutils {
     pub fn teardown() {
         let mut out = get_target_dir();
         out.push("target");
-        out.push("test.wasm");
+        out.push(format!("test{}.wasm", get_thread_id()));
         fs::remove_file(out.as_path()).ok();
+    }
+
+    pub fn get_thread_id() -> u64 {
+        // TODO(mtolmacs): There's an easier way on nightly, https://github.com/rust-lang/rust/issues/67939
+        let str = format!("{:#?}", std::thread::current().id());
+        let num = &str.as_str()[14..str.len() - 3];
+
+        str::parse::<u64>(num).expect("ThreadId debug format changed")
     }
 
     // Loads 'loopback' bytes from the end of the WASM binary specified by the 'path'

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -31,8 +31,18 @@ fn relative_paths() {
             let sourcemap = mapper.map_v3();
 
             // Any fixed relative path should have at least a `/` beforehand.
-            assert!(sourcemap.contains("/library/core/src/any.rs"));
-            assert!(sourcemap.contains("/library/core/src/panicking.rs"));
+            #[cfg(target_os = "windows")]
+            {
+                // TODO(mtolmacs): The slashes on Windows need to have a
+                // more robust matching method
+                assert!(sourcemap.contains(r#"\library/core/src\any.rs"#));
+                assert!(sourcemap.contains(r#"\library/core/src\panicking.rs"#));
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                assert!(sourcemap.contains("/library/core/src/any.rs"));
+                assert!(sourcemap.contains("/library/core/src/panicking.rs"));
+            }
         } else {
             unreachable!()
         }


### PR DESCRIPTION
I think my original bug description in #8 is just plain wrong. This is the first time I look at DWARF, so I'm just piecing things together here.

The [DWARF 4 specification](https://dwarfstd.org/doc/DWARF4.pdf#[{%22num%22%3A365%2C%22gen%22%3A0}%2C{%22name%22%3A%22XYZ%22}%2C0%2C370%2Cnull]) says the following about `include_directories`:
> Each path entry is either a full path name or is relative to the current directory of the compilation.

In the DWARF 5 specification, I couldn't find any mention of `include_directories`, so I guess Rust produces invalid DWARF 5, but I believe the new field is called [`directories`](https://dwarfstd.org/doc/DWARF5.pdf#section.6.2):
> The first entry is the current directory of the compilation. Each additional path entry is either a full path name or is relative to the current directory of the compilation.

So the fix here is to apply the directory of the compilation when encountering relative paths.

Fixes #8.