### PR TITLE
Bundle sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ use wasm2map::WASM;
 
 let mapper = WASM::load("/path/to/the/file.wasm");
     if let Ok(mut mapper) = mapper {
-        let sourcemap = mapper.map_v3();
+        let sourcemap = mapper.map_v3(false);
         mapper.patch("http://localhost:8080").expect("Failed to patch");
 }
 ```

--- a/cargo-wasm2map/src/main.rs
+++ b/cargo-wasm2map/src/main.rs
@@ -55,6 +55,13 @@ struct WasmFile {
         help = "Base URL of the sourcefile where it can be fetched from"
     )]
     base_url: Option<String>,
+
+    #[arg(
+        long,
+        requires = "patch",
+        help = "Bundle sourcefiles into the sourcemap"
+    )]
+    bundle_sources: bool,
 }
 
 fn main() -> Result<(), String> {
@@ -98,7 +105,7 @@ fn main() -> Result<(), String> {
     let mut wasm = WASM::load(&args.path).map_err(|err| err.to_string())?;
 
     // Generate the source map JSON for the loaded WASM
-    let sourcemap = wasm.map_v3();
+    let sourcemap = wasm.map_v3(args.bundle_sources);
 
     // Dump JSON to the map file
     fs::write(&map, sourcemap).map_err(|err| err.to_string())?;

--- a/wasm2map/src/error.rs
+++ b/wasm2map/src/error.rs
@@ -18,7 +18,7 @@ impl Display for Error {
 // the library codemuch more readable
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
-        Error {
+        Self {
             msg: value.to_string(),
         }
     }
@@ -26,7 +26,7 @@ impl From<std::io::Error> for Error {
 
 impl From<object::Error> for Error {
     fn from(value: object::Error) -> Self {
-        Error {
+        Self {
             msg: value.to_string(),
         }
     }
@@ -34,7 +34,7 @@ impl From<object::Error> for Error {
 
 impl From<gimli::Error> for Error {
     fn from(value: gimli::Error) -> Self {
-        Error {
+        Self {
             msg: value.to_string(),
         }
     }
@@ -42,7 +42,7 @@ impl From<gimli::Error> for Error {
 
 impl From<&str> for Error {
     fn from(value: &str) -> Self {
-        Error {
+        Self {
             msg: value.to_owned(),
         }
     }
@@ -50,13 +50,13 @@ impl From<&str> for Error {
 
 impl From<String> for Error {
     fn from(value: String) -> Self {
-        Error { msg: value }
+        Self { msg: value }
     }
 }
 
 impl From<std::num::TryFromIntError> for Error {
     fn from(value: std::num::TryFromIntError) -> Self {
-        Error {
+        Self {
             msg: value.to_string(),
         }
     }

--- a/wasm2map/src/json.rs
+++ b/wasm2map/src/json.rs
@@ -1,0 +1,84 @@
+use std::borrow::Cow;
+use std::str;
+
+// Inspired by:
+// <https://github.com/serde-rs/json/blob/a0ddb25ff6b86f43912f8fc637797bcbb920c61e/src/ser.rs#L1997-L2063>
+pub(crate) fn encode(string: &str) -> Cow<'_, str> {
+    const BB: u8 = b'b'; // \x08
+    const TT: u8 = b't'; // \x09
+    const NN: u8 = b'n'; // \x0A
+    const FF: u8 = b'f'; // \x0C
+    const RR: u8 = b'r'; // \x0D
+    const QU: u8 = b'"'; // \x22
+    const BS: u8 = b'\\'; // \x5C
+    const UU: u8 = b'u'; // \x00...\x1F except the ones above
+    const __: u8 = 0;
+
+    // Lookup table of escape sequences. A value of b'x' at index i means that byte
+    // i is escaped as "\x" in JSON. A value of 0 means that byte i is not escaped.
+    static ESCAPE: [u8; 256] = [
+        //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        UU, UU, UU, UU, UU, UU, UU, UU, BB, TT, NN, UU, FF, RR, UU, UU, // 0
+        UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, // 1
+        __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+        __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+    ];
+
+    let mut start = 0;
+    let mut new_string = String::new();
+
+    for (index, byte) in string.bytes().enumerate() {
+        let escape = ESCAPE[byte as usize];
+        if escape == 0 {
+            continue;
+        }
+
+        if start < index {
+            new_string += &string[start..index];
+        }
+
+        match escape {
+            QU => new_string += r#"\""#,
+            BS => new_string += r#"\\"#,
+            BB => new_string += r#"\b"#,
+            FF => new_string += r#"\f"#,
+            NN => new_string += r#"\n"#,
+            RR => new_string += r#"\r"#,
+            TT => new_string += r#"\t"#,
+            UU => {
+                static HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
+
+                new_string += str::from_utf8(&[
+                    b'\\',
+                    b'u',
+                    b'0',
+                    b'0',
+                    HEX_DIGITS[(byte >> 4) as usize],
+                    HEX_DIGITS[(byte & 0xF) as usize],
+                ])
+                .unwrap()
+            }
+            _ => unreachable!(),
+        }
+
+        start = index + 1;
+    }
+
+    if new_string.is_empty() {
+        string.into()
+    } else {
+        new_string.into()
+    }
+}

--- a/wasm2map/src/lib.rs
+++ b/wasm2map/src/lib.rs
@@ -52,7 +52,7 @@ pub struct CodePoint {
 ///
 /// let mapper = WASM::load("/path/to/the/file.wasm");
 /// if let Ok(mut mapper) = mapper {
-///     let sourcemap = mapper.map_v3();
+///     let sourcemap = mapper.map_v3(false);
 ///     mapper.patch("http://localhost:8080").expect("Failed to patch");
 /// }
 /// ```

--- a/wasm2map/src/lib.rs
+++ b/wasm2map/src/lib.rs
@@ -233,7 +233,14 @@ impl WASM {
         })
     }
 
-    /// Generate the sourcemap v3 JSON from the parsed WASM DWARF data
+    /// Generate the sourcemap v3 JSON from the parsed WASM DWARF data.
+    ///
+    /// The `bundle` parameter, when set to true, bundles the source code
+    /// of your project in the source map, so you can jump to the source
+    /// code from the console, not just the raw WASM bytecode.
+    ///
+    /// Note: The mapper is currently not able to package the source code
+    /// of crate dependencies, nor the rust library sources.
     ///
     /// # Example output
     ///
@@ -246,7 +253,14 @@ impl WASM {
     ///         "another/file/path.rs"
     ///         ...
     ///     ],
-    ///     "sourcesContent": null,
+    ///     "sourcesContent": [
+    ///         null,
+    ///         null,
+    ///         null,
+    ///         "fn main() {}",
+    ///         null,
+    ///         ...
+    ///     ],
     ///     "mappings": {
     ///         "yjBAiIA,qCAIiB,QAMhB,...,oBAAA"
     ///     }

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -14,7 +14,7 @@ const WASM_SOURCEMAPPINGURL_SECTION_NAME: &[u8] = b"sourceMappingURL";
 fn can_create_sourcemap() {
     testutils::run_test(|out| {
         if let Ok(mapper) = WASM::load(&out) {
-            let sourcemap = mapper.map_v3();
+            let sourcemap = mapper.map_v3(false);
 
             assert!(sourcemap.starts_with(r#"{"version":3,"names":[],"sources":["#));
             assert!(sourcemap.ends_with(r#""}"#));

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -226,7 +226,9 @@ fn test_derived_macros_present() {
         assert!(format!("{:#?}", codepoint).len() > 0);
         let wasm =
             WASM::load(out).expect("Loading WASM file is unsuccessful in derived macros test");
-        assert!(format!("{:#?}", wasm).len() > 0)
+        assert!(format!("{:#?}", wasm).len() > 0);
+        let error = Error::from("");
+        assert!(format!("{:#?}", error).len() > 0);
     })
 }
 

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -1,6 +1,6 @@
 use std::{fs, ops::Deref, path::PathBuf};
 
-use crate::{vlq, CodePoint, WASM};
+use crate::{error::Error, json::encode, vlq, CodePoint, WASM};
 
 // Consts needed to build golden versions of the binary WASM module section.
 // See wasm2map::WASM::patch() doc-comment for details.
@@ -230,6 +230,24 @@ fn test_derived_macros_present() {
         let error = Error::from("");
         assert!(format!("{:#?}", error).len() > 0);
     })
+}
+
+#[test]
+fn test_json_encode() {
+    let buf = [0; 32]
+        .iter()
+        .enumerate()
+        .map(|(count, _)| u8::try_from(count).expect("Data buffer is longer than 32"))
+        .collect::<Vec<u8>>();
+    assert_eq!(
+        encode(std::str::from_utf8(buf.as_slice()).expect("Wrong test buffer data")),
+        r#"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f"#
+    );
+    let buf2 = &[36, 35, 34, 92, 93, 94];
+    assert_eq!(
+        encode(std::str::from_utf8(buf2.as_slice()).expect("Wrong second test buffer data")),
+        r#"$#\"\\"#
+    );
 }
 
 mod testutils {

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -25,7 +25,7 @@ fn can_create_sourcemap() {
 }
 
 #[test]
-fn relative_paths() {
+fn relative_paths_are_considered() {
     testutils::run_test(|out| {
         if let Ok(mapper) = WASM::load(&out) {
             let sourcemap = mapper.map_v3(false);
@@ -50,7 +50,7 @@ fn relative_paths() {
 }
 
 #[test]
-fn bundle() {
+fn can_bundle_source() {
     testutils::run_test(|out| {
         if let Ok(mapper) = WASM::load(&out) {
             let sourcemap = mapper.map_v3(true);

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -54,8 +54,6 @@ fn bundle() {
     testutils::run_test(|out| {
         if let Ok(mapper) = WASM::load(&out) {
             let sourcemap = mapper.map_v3(true);
-            println!("{sourcemap}");
-
             assert!(sourcemap.contains("fn main() {}"));
         } else {
             unreachable!()

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -1,6 +1,6 @@
 use std::{fs, ops::Deref, path::PathBuf};
 
-use crate::{CodePoint, WASM};
+use crate::{vlq, CodePoint, WASM};
 
 // Consts needed to build golden versions of the binary WASM module section.
 // See wasm2map::WASM::patch() doc-comment for details.
@@ -28,7 +28,7 @@ fn can_create_sourcemap() {
 fn relative_paths() {
     testutils::run_test(|out| {
         if let Ok(mapper) = WASM::load(&out) {
-            let sourcemap = mapper.map_v3();
+            let sourcemap = mapper.map_v3(false);
 
             // Any fixed relative path should have at least a `/` beforehand.
             #[cfg(target_os = "windows")]
@@ -199,7 +199,7 @@ fn test_error_types() {
 
 #[test]
 fn test_numeric_encode_to_byte_sequence() {
-    assert_eq!(WASM::encode_uint_var(432), vec![176, 3])
+    assert_eq!(vlq::encode_uint_var(432), vec![176, 3])
 }
 
 #[test]

--- a/wasm2map/src/vlq.rs
+++ b/wasm2map/src/vlq.rs
@@ -1,0 +1,36 @@
+// Simple implementation of VLQ (variable-length quality) encoding to avoid
+// yet another dependency to accomplish this simple task
+//
+// TODO(mtolmacs): Use smallvec instead of string
+pub(crate) fn encode(value: i64) -> String {
+    const VLQ_CHARS: &[u8] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".as_bytes();
+    let mut x = if value >= 0 {
+        value << 1
+    } else {
+        (-value << 1) + 1
+    };
+    let mut result = String::new();
+
+    while x > 31 {
+        let idx: usize = (32 + (x & 31)).try_into().unwrap();
+        let ch: char = VLQ_CHARS[idx].into();
+        result.push(ch);
+        x >>= 5;
+    }
+    let idx: usize = x.try_into().unwrap();
+    let ch: char = VLQ_CHARS[idx].into();
+    result.push(ch);
+
+    result
+}
+
+pub(crate) fn encode_uint_var(mut n: u32) -> Vec<u8> {
+    let mut result = Vec::new();
+    while n > 127 {
+        result.push((128 | (n & 127)) as u8);
+        n >>= 7;
+    }
+    result.push(n as u8);
+    result
+}


### PR DESCRIPTION
This introduces a new parameter `--bundle-sources` that embeds the content of the source files into the sourcemap.

I figured adding a JSON encoder dependency is not desired, so I implemented a custom one. Apart from getting some inspiration from [`serde_json`](https://crates.io/crates/serde_json), I also made sure we follow the [specification](https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).

I was looking into how to fix the Rust sources, here are my preliminary findings:
- The [`trim-paths` RFC](https://rust-lang.github.io/rfcs/3127-trim-paths.html) would solve our problems without us having to do anything.
- There are a couple of workarounds to fix this on the Rust side:
  - Compile with `-Zbuild-std`.
  - Run a tool that fixes this beforehand (I'm not aware of one).
  - Custom toolchain with disabled virtualized paths.
- The Rust compiler has some code we can look at to learn how to devirtualize these paths: [source](https://github.com/rust-lang/rust/blob/0c2c243342ec2a2427f0624fac5ac59f0ee6fbcd/compiler/rustc_metadata/src/rmeta/decoder.rs#L1384-L1454).
- There is no perfectly reliable way to do this:
  - We can't differentiate between virtualized and real paths, except when they don't exist locally.
  - The hashes used in the virtualized path aren't available locally, unless we read them from the locally available debug information. (probably not a terrible idea)
  - Unlike the rust sources, which can be installed via `rustup component add rust-src`, related crates, like `compiler_builtins` or `dlmalloc`, aren't available locally at all unless the user specifically pulls them from crates.io.

Based on #9.
Fixes #3.