### PR TITLE
Fix source file paths on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,30 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test
         run: cargo test --locked --all-features --all-targets
-  coverage:
+  coverage-win:
+    runs-on: windows-latest
+    name: ubuntu / stable / coverage
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+          targets: wasm32-unknown-unknown
+      - name: cargo install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+      - name: cargo llvm-cov
+        run: cargo llvm-cov -p wasm2map --locked --all-features --lcov --output-path lcov.info
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+coverage-unix:
     runs-on: ubuntu-latest
     name: ubuntu / stable / coverage
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
-coverage-unix:
+  coverage-unix:
     runs-on: ubuntu-latest
     name: ubuntu / stable / coverage
     steps:

--- a/example/src/mem.rs
+++ b/example/src/mem.rs
@@ -9,7 +9,13 @@ unsafe extern "C" fn free(ptr: *mut u8, size: usize) {
     unsafe { std::alloc::dealloc(ptr, std::alloc::Layout::from_size_align(size, 1).unwrap()) }
 }
 
-pub unsafe fn into<'a>(str: &'a str) -> *const u8 {
+/// Turns Rust string into raw byte sequence the JS side can marshal into String
+///
+/// # Safety
+///
+/// The direct memory allocation requires unsafe and the memory has to be
+/// managed manually.
+pub unsafe fn into(str: &str) -> *const u8 {
     let bytes = str.as_bytes();
     let size = bytes.len().to_le_bytes();
     let ptr = std::alloc::alloc(std::alloc::Layout::from_size_align_unchecked(

--- a/wasm2map/src/json.rs
+++ b/wasm2map/src/json.rs
@@ -51,12 +51,12 @@ pub(crate) fn encode(string: &str) -> Cow<'_, str> {
 
         match escape {
             QU => new_string += r#"\""#,
-            BS => new_string += r#"\\"#,
-            BB => new_string += r#"\b"#,
-            FF => new_string += r#"\f"#,
-            NN => new_string += r#"\n"#,
-            RR => new_string += r#"\r"#,
-            TT => new_string += r#"\t"#,
+            BS => new_string += r"\\",
+            BB => new_string += r"\b",
+            FF => new_string += r"\f",
+            NN => new_string += r"\n",
+            RR => new_string += r"\r",
+            TT => new_string += r"\t",
             UU => {
                 static HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
 

--- a/wasm2map/src/lib.rs
+++ b/wasm2map/src/lib.rs
@@ -277,7 +277,19 @@ impl WASM {
         sourcemap.push('{');
         sourcemap.push_str(r#""version":3,"#);
         sourcemap.push_str(r#""names":[],"#);
-        sourcemap.push_str(format!(r#""sources":["{}"],"#, sources.join(r#"",""#)).as_str());
+        let processed_sources: Vec<String> = sources
+            .into_iter()
+            .map(|source| {
+                if let Some(pos) = source.find(':') {
+                    source[pos + 1..].to_string()
+                } else {
+                    source
+                }
+            })
+            .map(|source| source.replace('\\', "/"))
+            .collect();
+        sourcemap
+            .push_str(format!(r#""sources":["{}"],"#, processed_sources.join(r#"",""#)).as_str());
 
         if let Some(contents) = contents {
             debug_assert!(bundle);

--- a/wasm2map/src/test.rs
+++ b/wasm2map/src/test.rs
@@ -31,18 +31,8 @@ fn relative_paths_are_considered() {
             let sourcemap = mapper.map_v3(false);
 
             // Any fixed relative path should have at least a `/` beforehand.
-            #[cfg(target_os = "windows")]
-            {
-                // TODO(mtolmacs): The slashes on Windows need to have a
-                // more robust matching method
-                assert!(sourcemap.contains(r#"\library/core/src\any.rs"#));
-                assert!(sourcemap.contains(r#"\library/core/src\panicking.rs"#));
-            }
-            #[cfg(not(target_os = "windows"))]
-            {
-                assert!(sourcemap.contains("/library/core/src/any.rs"));
-                assert!(sourcemap.contains("/library/core/src/panicking.rs"));
-            }
+            assert!(sourcemap.contains("/library/core/src/any.rs"));
+            assert!(sourcemap.contains("/library/core/src/panicking.rs"));
         } else {
             unreachable!()
         }


### PR DESCRIPTION
On Windows the paths for source files contain backslash (`\`) characters as well as drive letters, which is an issue, because backslash is used as the escape character marker.